### PR TITLE
unix: Include string.h

### DIFF
--- a/router/unix.c
+++ b/router/unix.c
@@ -34,6 +34,7 @@
 
 #include <fcntl.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "diag.h"
 #include "dm.h"


### PR DESCRIPTION
This fixes a bunch of implicit function declaration issues under musl libc.