### PR TITLE
Passthrough Control Packets to peripherals

### DIFF
--- a/router/app_cmds.c
+++ b/router/app_cmds.c
@@ -53,7 +53,6 @@
 #define MOBILE_MODEL_STRING		"DB410C"
 #define MSM_REVISION_NUMBER		2
 
-#define DIAG_CMD_DIAG_SUBSYS	18
 #define DIAG_CMD_DIAG_GET_DIAG_ID	0x222
 
 static int handle_diag_version(struct diag_client *client, const void *buf,

--- a/router/diag.h
+++ b/router/diag.h
@@ -63,6 +63,7 @@
 
 #define DIAG_CMD_SUBSYS_DISPATCH       75
 #define DIAG_CMD_SUBSYS_DISPATCH_V2	128
+#define DIAG_CMD_DIAG_SUBSYS	18
 
 enum {
 	DIAG_HW_ACCEL_TYPE_STM = 1,
@@ -84,6 +85,26 @@ struct diag_global_info {
 	uint32_t diagid_feature[DIAGID_FEATURE_COUNT];
 	uint32_t diagid_status[DIAGID_FEATURE_COUNT];
 	uint32_t diag_hw_accel[DIAGID_FEATURE_COUNT];
+};
+
+struct diag_pkt_header_t {
+	uint8_t cmd_code;
+	uint8_t subsys_id;
+	uint16_t subsys_cmd_code;
+};
+
+struct diag_hw_accel_op_t {
+	uint8_t hw_accel_type;
+	uint8_t hw_accel_ver;
+	uint32_t diagid_mask;
+};
+
+struct diag_hw_accel_cmd_req_t {
+	struct diag_pkt_header_t header;
+	uint8_t version;
+	uint8_t operation;
+	uint16_t reserved;
+	struct diag_hw_accel_op_t op_req;
 };
 
 struct diag_client;

--- a/router/diag.h
+++ b/router/diag.h
@@ -64,6 +64,28 @@
 #define DIAG_CMD_SUBSYS_DISPATCH       75
 #define DIAG_CMD_SUBSYS_DISPATCH_V2	128
 
+enum {
+	DIAG_HW_ACCEL_TYPE_STM = 1,
+	DIAG_HW_ACCEL_TYPE_ATB,
+
+	DIAG_HW_ACCEL_TYPE_MAX
+} diag_hw_accel_type;
+
+enum {
+	DIAG_HW_ACCEL_CMD_VER_1 = 1,
+	DIAG_HW_ACCEL_CMD_VER_2,
+
+	DIAG_HW_ACCEL_CMD_VER_MAX
+} diag_hw_accel_cmd_ver;
+
+#define DIAGID_FEATURE_COUNT	3
+
+struct diag_global_info {
+	uint32_t diagid_feature[DIAGID_FEATURE_COUNT];
+	uint32_t diagid_status[DIAGID_FEATURE_COUNT];
+	uint32_t diag_hw_accel[DIAGID_FEATURE_COUNT];
+};
+
 struct diag_client;
 
 struct peripheral {
@@ -138,5 +160,7 @@ void register_common_cmd(unsigned int cmd, int(*cb)(struct diag_client *client,
 
 void register_app_cmds(void);
 void register_common_cmds(void);
+
+struct diag_global_info *diag_get_global_info(void);
 
 #endif

--- a/router/diag_cntl.c
+++ b/router/diag_cntl.c
@@ -626,6 +626,41 @@ void process_diagid_feature_mask(uint32_t diag_id, const uint32_t feature_mask)
 	}
 }
 
+#define QUERY_FEATURE_MASK_DATA_TYPE 0x8000
+struct query_pd_feature_mask
+{
+	int data_type;
+	uint32_t diagid_mask_supported;
+	uint32_t diagid_mask_enabled;
+};
+int diag_cntl_query_featuremask(struct diag_client *dm, struct diag_query_hw_accel_mask_rsp_t *query_params)
+{
+
+	struct diag_global_info *diag_info = diag_get_global_info();
+	struct query_pd_feature_mask params = {0};
+	int f_index = -1;
+	if (!query_params || !diag_info)
+		return -EINVAL;
+
+	if (query_params->hw_accel_type >= DIAG_HW_ACCEL_TYPE_MAX ||
+		query_params->hw_accel_ver >= DIAG_HW_ACCEL_CMD_VER_MAX) {
+		return -EINVAL;
+	}
+
+	f_index = diag_map_hw_accel_to_type(query_params->hw_accel_type,
+				query_params->hw_accel_ver);
+	params.data_type = QUERY_FEATURE_MASK_DATA_TYPE;
+	if (f_index < 0) {
+		params.diagid_mask_supported = 0;
+		params.diagid_mask_enabled = 0;
+	} else {
+		params.diagid_mask_supported = diag_info->diagid_feature[f_index];
+		params.diagid_mask_enabled = diag_info->diagid_status[f_index];
+	}
+	dm_send(dm, &params, sizeof(params));
+	return 0;
+}
+
 struct list_head *diag_get_diag_ids_head(void)
 {
 	return &diag_ids;

--- a/router/diag_cntl.c
+++ b/router/diag_cntl.c
@@ -582,6 +582,50 @@ void diag_cntl_set_buffering_mode(struct peripheral *perif, int mode)
 	}
 }
 
+void diag_map_feature_to_hw_accel(uint8_t index, uint8_t *hw_accel_type, uint8_t *hw_accel_ver)
+{
+	*hw_accel_type = 0;
+	*hw_accel_ver = 0;
+
+	switch (index) {
+	case DIAG_HW_ACCEL_TYPE_STM:
+		*hw_accel_type = DIAG_HW_ACCEL_TYPE_STM;
+		*hw_accel_ver = DIAG_HW_ACCEL_CMD_VER_1;
+		break;
+	case DIAG_HW_ACCEL_TYPE_ATB:
+		*hw_accel_type = DIAG_HW_ACCEL_TYPE_ATB;
+		*hw_accel_ver = DIAG_HW_ACCEL_CMD_VER_1;
+		break;
+	default:
+		break;
+	}
+}
+
+
+void process_diagid_feature_mask(uint32_t diag_id, const uint32_t feature_mask)
+{
+	struct diag_global_info *diag_info = diag_get_global_info();
+	uint32_t diagid_mask_bit = 0, feature_id_mask = 0;
+	uint8_t hw_accel_type = 0, hw_accel_ver = 0;
+	int i = 0;
+
+	if (!feature_mask || !diag_info)
+		return;
+
+	diagid_mask_bit = 1 << (diag_id - 1);
+	for (i = 0; i < DIAGID_FEATURE_COUNT; i++) {
+		feature_id_mask = (feature_mask & (1 << i));
+		if (feature_id_mask){
+			diag_info->diagid_feature[i] |= diagid_mask_bit;
+		}
+		feature_id_mask = 0;
+
+		diag_map_feature_to_hw_accel(i, &hw_accel_type, &hw_accel_ver);
+		if (hw_accel_type && hw_accel_ver)
+			diag_info->diag_hw_accel[i] = 1;
+	}
+}
+
 struct list_head *diag_get_diag_ids_head(void)
 {
 	return &diag_ids;
@@ -642,6 +686,7 @@ static int diag_cntl_process_diag_id(struct peripheral *peripheral, struct diag_
 	struct diag_cntl_cmd_diag_id_v2 *pkt_v2 = to_cmd_diag_id_v2(hdr);
 	struct diag_cntl_cmd_diag_id *pkt = to_cmd_diagid(hdr);
 	uint32_t version = 0, local_diag_id = 0;
+	uint32_t feature_mask = 0;
 	static uint32_t diag_id = DIAG_ID_APPS;
 	uint8_t resp_buffer[DIAG_MAX_RSP_SIZE] = {0};
 	uint8_t process_name_len = 0;
@@ -653,6 +698,7 @@ static int diag_cntl_process_diag_id(struct peripheral *peripheral, struct diag_
 		if (len < sizeof(struct diag_cntl_cmd_diag_id_v2))
 			return -EINVAL;
 		process_name = (char *)&pkt_v2->feature_mask + pkt_v2->feature_len;
+		memcpy((uint32_t *)&feature_mask, pkt_v2->feature_mask, pkt_v2->feature_len);
 	} else {
 		if (len < sizeof(struct diag_cntl_cmd_diag_id))
 			return -EINVAL;
@@ -674,6 +720,8 @@ static int diag_cntl_process_diag_id(struct peripheral *peripheral, struct diag_
 			return -EINVAL;
 	}
 	diag_id = local_diag_id;
+	if (peripheral->features & DIAG_FEATURE_DIAG_ID_FEATURE_MASK)
+		process_diagid_feature_mask(diag_id, feature_mask);
 
 	struct diag_cntl_cmd_diag_id *resp = (struct diag_cntl_cmd_diag_id *)resp_buffer;
 	resp->diag_id = diag_id;

--- a/router/diag_cntl.c
+++ b/router/diag_cntl.c
@@ -42,6 +42,7 @@
 #include "masks.h"
 #include "peripheral.h"
 #include "util.h"
+#include "list.h"
 
 #define DIAG_CTRL_MSG_DTR               2
 #define DIAG_CTRL_MSG_DIAGMODE          3
@@ -67,6 +68,12 @@
 #define DIAG_CTRL_MSG_DCI_HANDSHAKE_PKT         29
 #define DIAG_CTRL_MSG_PD_STATUS                 30
 #define DIAG_CTRL_MSG_TIME_SYNC_PKT             31
+#define DIAG_CTRL_MSG_PASS_THRU                 35
+
+#define DIAG_HW_ACCEL_CMD		0x224
+#define DIAG_HW_ACCEL_OP_DISABLE	0
+#define DIAG_HW_ACCEL_OP_ENABLE		1
+#define DIAG_HW_ACCEL_OP_QUERY		2
 
 struct diag_cntl_hdr {
 	uint32_t cmd;
@@ -223,6 +230,15 @@ struct diag_cntl_cmd_diag_id_v2 {
 	char process_name[];
 } __packed;
  #define to_cmd_diag_id_v2(h) container_of(h, struct diag_cntl_cmd_diag_id_v2, hdr)
+
+ struct diag_cntl_cmd_passthru {
+	struct diag_cntl_hdr hdr;
+	uint32_t version;
+	uint32_t diagid_mask;
+	uint8_t hw_accel_type;
+	uint8_t hw_accel_ver;
+	uint8_t control_data;
+} __packed;
 
 struct list_head diag_ids = LIST_INIT(diag_ids);
 
@@ -601,6 +617,113 @@ void diag_map_feature_to_hw_accel(uint8_t index, uint8_t *hw_accel_type, uint8_t
 	}
 }
 
+int diag_map_hw_accel_to_type(uint8_t hw_accel_type, uint8_t hw_accel_ver)
+{
+	int index = -EINVAL;
+
+	if (hw_accel_ver == DIAG_HW_ACCEL_CMD_VER_1) {
+		switch (hw_accel_type) {
+		case DIAG_HW_ACCEL_TYPE_STM:
+			index = DIAG_HW_ACCEL_TYPE_STM;
+			break;
+		case DIAG_HW_ACCEL_TYPE_ATB:
+			index = DIAG_HW_ACCEL_TYPE_ATB;
+			break;
+		default:
+			index = -EINVAL;
+			break;
+		}
+	}
+
+	return index;
+}
+
+int diag_cntl_send_passthru_control_pkt(struct diag_hw_accel_cmd_req_t *req_params)
+{
+	struct diag_cntl_cmd_passthru pkt = {0};
+	int f_index = -1, err = 0;
+	uint32_t diagid_mask = 0, diagid_status = 0;
+	uint8_t i, hw_accel_type, hw_accel_ver;
+	struct peripheral *peripheral;
+	struct diag_global_info *diag_info = NULL;
+
+	if (!req_params || req_params->operation > DIAG_HW_ACCEL_OP_QUERY) {
+		return -EINVAL;
+	}
+
+	hw_accel_type = req_params->op_req.hw_accel_type;
+	hw_accel_ver = req_params->op_req.hw_accel_ver;
+	if (hw_accel_type >= DIAG_HW_ACCEL_TYPE_MAX || hw_accel_type < 0 ||
+		hw_accel_ver != DIAG_HW_ACCEL_CMD_VER_1) {
+		return -EINVAL;
+	}
+
+	diag_info = diag_get_global_info();
+	f_index = diag_map_hw_accel_to_type(hw_accel_type, hw_accel_ver);
+	if (f_index < 0)
+		return -EINVAL;
+
+	diagid_mask = req_params->op_req.diagid_mask;
+	diagid_status = diag_info->diagid_feature[f_index] & diagid_mask;
+
+	if (req_params->operation == DIAG_HW_ACCEL_OP_DISABLE) {
+		diag_info->diagid_status[f_index] &= ~diagid_status;
+	} else {
+		diag_info->diagid_feature[f_index] |= diagid_status;
+		for (i = 0; i < DIAGID_FEATURE_COUNT; i++) {
+			if (i == f_index || !diag_info->diag_hw_accel[i])
+				continue;
+			diag_info->diagid_status[i] &= ~(diag_info->diagid_feature[i] & diagid_mask);
+		}
+	}
+
+	req_params->op_req.diagid_mask = diag_info->diagid_status[f_index];
+	pkt.hdr.cmd = DIAG_CTRL_MSG_PASS_THRU;
+	pkt.hdr.len = sizeof(pkt)- sizeof(pkt.hdr);
+	pkt.version = 1;
+	pkt.diagid_mask = diagid_mask;
+	pkt.hw_accel_type = hw_accel_type;
+	pkt.hw_accel_ver = hw_accel_ver;
+	pkt.control_data = req_params->operation;
+
+	list_for_each_entry(peripheral, &peripherals, node) {
+		if (peripheral->features & DIAG_FEATURE_DIAG_ID_FEATURE_MASK) {
+			queue_push(&peripheral->cntlq, &pkt, sizeof(pkt));
+		}
+	}
+
+	return 0;
+}
+
+void diag_send_hw_accel_status(struct peripheral *peripheral)
+{
+	struct diag_hw_accel_cmd_req_t req_params = {0};
+	struct diag_global_info *diag_info = NULL;
+	uint8_t hw_accel_type = 0, hw_accel_ver = 0;
+	int feature = 0;
+
+	diag_info = diag_get_global_info();
+	for (feature = 0; feature < DIAGID_FEATURE_COUNT; feature++) {
+		if (!diag_info->diag_hw_accel[feature])
+			continue;
+
+		if (diag_info->diagid_feature[feature] &
+			diag_info->diagid_status[feature]) {
+			diag_map_feature_to_hw_accel(feature, &hw_accel_type, &hw_accel_ver);
+			req_params.header.cmd_code = DIAG_CMD_SUBSYS_DISPATCH;
+			req_params.header.subsys_id = DIAG_CMD_DIAG_SUBSYS;
+			req_params.header.subsys_cmd_code = DIAG_HW_ACCEL_CMD;
+			req_params.version = 1;
+			req_params.reserved = 0;
+			req_params.operation = DIAG_HW_ACCEL_OP_ENABLE;
+			req_params.op_req.hw_accel_type = hw_accel_type;
+			req_params.op_req.hw_accel_ver = DIAG_HW_ACCEL_CMD_VER_1;
+			req_params.op_req.diagid_mask = diag_info->diagid_status[feature];
+			if (peripheral->features & DIAG_FEATURE_DIAG_ID_FEATURE_MASK)
+				diag_cntl_send_passthru_control_pkt(&req_params);
+		}
+	}
+}
 
 void process_diagid_feature_mask(uint32_t diag_id, const uint32_t feature_mask)
 {

--- a/router/diag_cntl.h
+++ b/router/diag_cntl.h
@@ -56,6 +56,13 @@ struct diag_id_tbl_t {
 	struct diag_id_info diagid_info;
 };
 
+struct diag_query_hw_accel_mask_rsp_t {
+	uint8_t hw_accel_type;
+	uint8_t hw_accel_ver;
+	uint32_t diagid_mask_supported;
+	uint32_t diagid_mask_enabled;
+};
+
 int diag_cntl_recv(struct peripheral *perif, const void *buf, size_t len);
 void diag_cntl_send_log_mask(struct peripheral *peripheral, uint32_t equip_id);
 void diag_cntl_send_msg_mask(struct peripheral *peripheral, struct diag_ssid_range_t *range);
@@ -68,5 +75,7 @@ void diag_cntl_set_diag_mode(struct peripheral *perif, bool real_time);
 void diag_cntl_set_buffering_mode(struct peripheral *perif, int mode);
 
 struct list_head *diag_get_diag_ids_head(void);
+
+int diag_cntl_query_featuremask(struct diag_client *dm, struct diag_query_hw_accel_mask_rsp_t *query_params);
 
 #endif

--- a/router/diag_cntl.h
+++ b/router/diag_cntl.h
@@ -75,7 +75,7 @@ void diag_cntl_set_diag_mode(struct peripheral *perif, bool real_time);
 void diag_cntl_set_buffering_mode(struct peripheral *perif, int mode);
 
 struct list_head *diag_get_diag_ids_head(void);
-
+int diag_cntl_send_passthru_control_pkt(struct diag_hw_accel_cmd_req_t *req_params);
 int diag_cntl_query_featuremask(struct diag_client *dm, struct diag_query_hw_accel_mask_rsp_t *query_params);
 
 #endif

--- a/router/dm.c
+++ b/router/dm.c
@@ -45,6 +45,8 @@
  */
 
 #define DATA_TYPE_QUERY_FEATUREMASK	42
+#define DATA_TYPE_PASSTHRU_CONTROL 43
+#define PASSTHRU_MASKS_TYPE	0x00002000
 
 struct diag_client {
 	const char *name;
@@ -125,6 +127,25 @@ static int dm_recv_hdlc(struct diag_client *dm)
 	return ret;
 }
 
+void diag_send_passthru_control_pkt(struct diag_client *dm, struct diag_hw_accel_cmd_req_t *req_params)
+{
+	struct diag_hw_diagid_mask
+	{
+		int data_type;
+		int ret_val;
+		uint32_t diagid_mask;
+	};
+	struct diag_hw_diagid_mask params;
+	int ret;
+
+	ret = diag_cntl_send_passthru_control_pkt(req_params);
+	params.data_type = PASSTHRU_MASKS_TYPE;
+	params.ret_val = ret;
+	params.diagid_mask = req_params->op_req.diagid_mask;
+
+	dm_send(dm, &params, sizeof(params));
+}
+
 static int dm_recv_raw(struct diag_client *dm)
 {
 	int saved_errno;
@@ -151,6 +172,9 @@ static int dm_recv_raw(struct diag_client *dm)
 
 		dmpkt = (struct dm_pkt *)buf;
 		switch (dmpkt->type) {
+			case DATA_TYPE_PASSTHRU_CONTROL:
+				diag_send_passthru_control_pkt(dm, buf + 4);
+				break;
 			case DATA_TYPE_QUERY_FEATUREMASK:
 				diag_cntl_query_featuremask(dm, buf + 4);
 				break;

--- a/router/dm.c
+++ b/router/dm.c
@@ -44,6 +44,8 @@
  * DOC: Diagnostic Monitor
  */
 
+#define DATA_TYPE_QUERY_FEATUREMASK	42
+
 struct diag_client {
 	const char *name;
 	int fd;
@@ -128,6 +130,11 @@ static int dm_recv_raw(struct diag_client *dm)
 	int saved_errno;
 	unsigned char buf[4096];
 	ssize_t n;
+	struct dm_pkt{
+		int type;
+		unsigned char pkt;
+	};
+	struct dm_pkt *dmpkt;
 
 	for (;;) {
 		n = read(dm->in_fd, buf, sizeof(buf));
@@ -140,6 +147,15 @@ static int dm_recv_raw(struct diag_client *dm)
 			saved_errno = -errno;
 			warn("Failed to read from %s\n", dm->name);
 			return saved_errno;
+		}
+
+		dmpkt = (struct dm_pkt *)buf;
+		switch (dmpkt->type) {
+			case DATA_TYPE_QUERY_FEATUREMASK:
+				diag_cntl_query_featuremask(dm, buf + 4);
+				break;
+			default:
+				break;
 		}
 
 		diag_client_handle_command(dm, buf, n);


### PR DESCRIPTION
Add support to negotiate the current hw accel status through the passthrough control packets​.