### PR TITLE
Replace scatter-gather with direct copy for NHDLC framing

### DIFF
--- a/router/diag.c
+++ b/router/diag.c
@@ -47,75 +47,48 @@
 
 struct list_head diag_cmds = LIST_INIT(diag_cmds);
 
-static size_t iovec_total_len(struct iovec *iov, int iovcnt)
+void queue_push_nhdlc_flow(struct list_head *queue, const void *msg, size_t msglen,
+			struct watch_flow *flow)
 {
-	size_t total = 0;
+	size_t len;
+	size_t off = 0;
+	struct mbuf *mbuf = NULL;
+	uint8_t *ptr = NULL;
 
-	for (int i = 0; i < iovcnt; i++) {
-		total += iov[i].iov_len;
-	}
+	len = msglen + sizeof(struct diag_pkt_frame) + sizeof(uint8_t);
 
-	return total;
-}
-
-void queue_push_sg_flow(struct list_head *queue, struct iovec *iov, int iovcnt,
-			 struct watch_flow *flow)
-{
-	struct mbuf *mbuf;
-	void *ptr, *src;
-	size_t iovec_len, len;
-	size_t offset = 0;
-
-	iovec_len = iovec_total_len(iov, iovcnt);
-	mbuf = mbuf_alloc(sizeof(*mbuf) + iovec_len);
+	mbuf = mbuf_alloc(len);
 	if (!mbuf) {
 		warnx("Diag: %s: failed to allocate memory", __func__);
 		return;
 	}
 
-	ptr = mbuf_put(mbuf, sizeof(*mbuf) + iovec_len);
+	ptr = mbuf_put(mbuf, len);
 	if (!ptr) {
-		warnx("Diag: invalid ptr, dropping pkt of len: %zu\n", sizeof(*mbuf) + iovec_len);
+		warnx("Diag: %s: invalid ptr, dropping pkt of len: %zu\n", __func__, len);
 		free(mbuf);
 		return;
 	}
 
-	for (int i = 0; i < iovcnt; ++i) {
-		src = iov[i].iov_base;
-		len = iov[i].iov_len;
-		memcpy(ptr + offset, src, len);
-		offset += len;
-	}
+	struct diag_pkt_frame *header = (struct diag_pkt_frame *)ptr;
 
-	mbuf->offset = offset;
-	mbuf->size = iovec_len;
+	header->start = NHDLC_CONTROL_CHAR;
+	header->version = 1;
+	header->length = msglen;
+
+	off += sizeof(struct diag_pkt_frame);
+	/* copy the actual packet */
+	memcpy(ptr + off, msg, msglen);
+	off += msglen; 
+
+	((uint8_t *)ptr)[off] = NHDLC_CONTROL_CHAR;
+	off += sizeof(uint8_t);
+
+	mbuf->offset = off;
 	mbuf->flow = flow;
-
+	
 	watch_flow_inc(flow);
 	list_add(queue, &mbuf->node);
-}
-
-int nhdlc_enqueue_flow(struct list_head *queue, const void *msg, size_t msglen,
-			struct watch_flow *flow)
-{
-	struct diag_pkt_frame header = {0};
-	uint8_t tail = NHDLC_CONTROL_CHAR;
-	struct iovec iov[3];
-
-	header.start = NHDLC_CONTROL_CHAR;
-	header.version = 1;
-	header.length = msglen;
-
-	iov[0].iov_base = &header;
-	iov[0].iov_len = sizeof(header);
-	iov[1].iov_base = msg;
-	iov[1].iov_len = msglen;
-	iov[2].iov_base = &tail;
-	iov[2].iov_len = sizeof(uint8_t);
-
-	queue_push_sg_flow(queue, iov, sizeof(iov) / sizeof(iov[0]), flow);
-
-	return 0;
 }
 
 void queue_push_flow(struct list_head *queue, const void *msg, size_t msglen,

--- a/router/diag.h
+++ b/router/diag.h
@@ -135,8 +135,8 @@ int diag_client_handle_command(struct diag_client *client, uint8_t *data, size_t
 int hdlc_enqueue(struct list_head *queue, const void *buf, size_t msglen);
 int hdlc_enqueue_flow(struct list_head *queue, const void *buf, size_t msglen,
 		 struct watch_flow *flow);
-int nhdlc_enqueue_flow(struct list_head *queue, const void *msg, size_t msglen,
-		 struct watch_flow *flow);
+void queue_push_nhdlc_flow(struct list_head *queue, const void *msg, size_t msglen,
+			struct watch_flow *flow);
 
 void register_fallback_cmd(unsigned int cmd,
 			   int(*cb)(struct diag_client *client,

--- a/router/dm.c
+++ b/router/dm.c
@@ -254,7 +254,7 @@ static int dm_send_flow(struct diag_client *dm, const void *ptr, size_t len,
 		hdlc_enqueue_flow(&dm->outq, ptr, len, flow);
 		break;
 	case DIAG_ENCODE_NHDLC:
-		nhdlc_enqueue_flow(&dm->outq, ptr, len, flow);
+		queue_push_nhdlc_flow(&dm->outq, ptr, len, flow);
 		break;
 	default:
 		warn("Diag: send error encode type %d\n", dm->encode_type);


### PR DESCRIPTION
Replace iovec-based packet assembly with direct linear copy in _queue_push_ndlc_flow()_.
The scatter-gather approach was creating temporary stack variables and looping through iovecs unnecessarily for simple header + msg + tail construction.

Scatter-gather makes sense for zero-copy I/O, not for building new packets from scratch.