### PR TITLE
send_data: Fix abstract socket path copy truncation

### DIFF
--- a/tools/send_data.c
+++ b/tools/send_data.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
 
 	memset(&addr, 0, sizeof(addr));
 	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, "\0diag", sizeof(addr.sun_path)-1);
+	memcpy(addr.sun_path, "\0diag", 5);
 
 	ret = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
 	if (ret < 0)


### PR DESCRIPTION
strncpy() stops at the first null byte, which truncates the abstract socket name "\0diag" to an empty string. This will result in a "Diag response: Bad command" failure, fix this by using memcpy to copy the full 5 bytes including the leading null that marks the abstract namespace.