### PR TITLE
diag-router: Add support for SoC Control Processor (SoCCP)

### DIFF
--- a/router/peripheral-qrtr.c
+++ b/router/peripheral-qrtr.c
@@ -53,6 +53,7 @@
 #define DIAG_INSTANCE_BASE_SENSORS	192
 #define DIAG_INSTANCE_BASE_CDSP		256
 #define DIAG_INSTANCE_BASE_WDSP		320
+#define DIAG_INSTANCE_BASE_SOCCP	832
 
 enum {
 	DIAG_INSTANCE_CNTL,
@@ -333,6 +334,7 @@ int peripheral_qrtr_init(void)
 	qrtr_perif_init_subsystem("sensors", DIAG_INSTANCE_BASE_SENSORS);
 	qrtr_perif_init_subsystem("cdsp", DIAG_INSTANCE_BASE_CDSP);
 	qrtr_perif_init_subsystem("wdsp", DIAG_INSTANCE_BASE_WDSP);
+	qrtr_perif_init_subsystem("soccp", DIAG_INSTANCE_BASE_SOCCP);
 
 	return 0;
 }


### PR DESCRIPTION
With the late attach support for SoCCP close to landing upstream (https://lore.kernel.org/lkml/20260623-knp-soccp-v7-0-1ec7bb5c9fec@oss.qualcomm.com/) register a QRTR peripheral for the SoC control processor so diag-router can communicate with the soccp subsystem. One can rely on the following commands to trigger SSR on SoCCP using send_data.

error fatal: send_data 75 37 03 152 00
wdog bite: send_data 75 37 03 152 01
Software exception (Null pointer): send_data 75 37 03 152 02
software exception (div by 0): send_data 75 37 03 152 03